### PR TITLE
implemented extract_node caching

### DIFF
--- a/project-manager/inspect/helpers.gd
+++ b/project-manager/inspect/helpers.gd
@@ -1,10 +1,14 @@
 @tool
 
 static var engine_root: Node = Engine.get_main_loop().root
+static var path_cache := {}
 
-static func extract_node(arr: Array, root := engine_root, include_internal := true):
+static func extract_node(arr: Array, root := engine_root, include_internal := true, use_cache := true) -> Node:
 	var current_node := root
 	var next_node: Node = null
+	
+	if use_cache and arr in path_cache:
+		return path_cache[arr]
 	
 	for item in arr:
 		next_node = null
@@ -36,6 +40,9 @@ static func extract_node(arr: Array, root := engine_root, include_internal := tr
 			return null
 		else:
 			current_node = next_node
+	
+	if use_cache:
+		path_cache[arr] = current_node
 	
 	return current_node
 


### PR DESCRIPTION
calling `extract_node` now caches and returns the cache by default.

The main purpose is when multiple plugins try to target the same index path, but one of them has moved the node somewhere else. In that case, the 2nd plugin would be expecting some node, but it wouldn't exist there anymore.

With the cache, if both plugins use the same array for extraction, they will get the same node, even if it was moved by one of them.